### PR TITLE
Changed interface to retrieve contract named keys with Get* methods

### DIFF
--- a/Casper.Network.SDK.Clients.Test/CEP47ClientTest.cs
+++ b/Casper.Network.SDK.Clients.Test/CEP47ClientTest.cs
@@ -106,8 +106,7 @@ namespace Casper.Network.SDK.Clients.Test
         {
             _cep47Client = new CEP47Client(new NetCasperClient(_nodeAddress), CHAIN_NAME);
 
-            var b = await _cep47Client.SetContractHash(_ownerAccount.PublicKey, $"{TOKEN_NAME}_contract_hash");
-            Assert.IsTrue(b);
+            await _cep47Client.SetContractHash(_ownerAccount.PublicKey, $"{TOKEN_NAME}_contract_hash");
 
             if (_contractHash != null)
                 Assert.AreEqual(_contractHash.ToString(), _cep47Client.ContractHash.ToString());
@@ -141,30 +140,19 @@ namespace Casper.Network.SDK.Clients.Test
             Assert.IsNotNull(_contractHash, "This test must run after InstallContractTest");
             var client = new CEP47Client(new NetCasperClient(_nodeAddress), CHAIN_NAME);
 
-            var b = await client.SetContractHash(_contractHash.ToString());
-            Assert.IsTrue(b);
+            client.SetContractHash(_contractHash.ToString());
 
-            Assert.AreEqual(TOKEN_NAME, client.Name);
-            Assert.AreEqual(TOKEN_SYMBOL, client.Symbol);
+            Assert.AreEqual(TOKEN_NAME, await client.GetName());
+            Assert.AreEqual(TOKEN_SYMBOL, await client.GetSymbol());
             Assert.AreEqual(BigInteger.Zero, await client.GetTotalSupply());
 
-            Assert.IsNotNull(client.Meta);
+            var metadata = await client.GetMetadata();
+            Assert.IsNotNull(metadata);
+            Assert.AreEqual(1, metadata.Count());
+            Assert.IsTrue(metadata.ContainsKey("origin"));
 
             Assert.IsNotNull(client.ContractHash);
             Assert.AreEqual(_contractHash.ToString(), client.ContractHash.ToString());
-        }
-        
-        [Test, Order(3)]
-        public void SetContractPackageHashTest()
-        {
-            Assert.IsNotNull(_contractPackageHash, "This test must run after InstallContractTest");
-            var client = new CEP47Client(new NetCasperClient(_nodeAddress), CHAIN_NAME);
-
-            var b = client.SetContractPackageHash(_contractPackageHash, null, true);
-            Assert.IsTrue(b);
-
-            var ex = Assert.Catch(() => client.SetContractPackageHash(_contractPackageHash, null, false));
-            Assert.IsNotNull(ex);
         }
 
         [Test, Order(3)]
@@ -203,8 +191,7 @@ namespace Casper.Network.SDK.Clients.Test
             Assert.IsNotNull(_contractPackageHash, "This test must run after InstallContractTest");
             var client = new CEP47Client(new NetCasperClient(_nodeAddress), CHAIN_NAME);
 
-            var b = client.SetContractPackageHash(_contractPackageHash, null, true);
-            Assert.IsTrue(b);
+            client.SetContractPackageHash(_contractPackageHash, null);
             
             var tokenMeta = new Dictionary<string, string>
             {

--- a/Casper.Network.SDK.Clients.Test/ERC20ClientTest.cs
+++ b/Casper.Network.SDK.Clients.Test/ERC20ClientTest.cs
@@ -100,8 +100,7 @@ namespace Casper.Network.SDK.Clients.Test
         {
             _erc20Client = new ERC20Client(new NetCasperClient(_nodeAddress), CHAIN_NAME);
 
-            var b = await _erc20Client.SetContractHash(_ownerAccount.PublicKey, "erc20_token_contract");
-            Assert.IsTrue(b);
+            await _erc20Client.SetContractHash(_ownerAccount.PublicKey, "erc20_token_contract");
 
             if (_contractHash != null)
                 Assert.AreEqual(_contractHash.ToString(), _erc20Client.ContractHash.ToString());
@@ -126,29 +125,15 @@ namespace Casper.Network.SDK.Clients.Test
             Assert.IsNotNull(_contractHash, "This test must run after InstallContractTest");
             var client = new ERC20Client(new NetCasperClient(_nodeAddress), CHAIN_NAME);
 
-            var b = await client.SetContractHash(_contractHash.ToString());
-            Assert.IsTrue(b);
+            client.SetContractHash(_contractHash.ToString());
             
-            Assert.AreEqual(TOKEN_NAME, client.Name);
-            Assert.AreEqual(TOKEN_SYMBOL, client.Symbol);
-            Assert.AreEqual(TOKEN_DECIMALS, client.Decimals);
-            Assert.AreEqual(BigInteger.Parse(TOKEN_SUPPLY), client.TotalSupply);
+            Assert.AreEqual(TOKEN_NAME, await client.GetName());
+            Assert.AreEqual(TOKEN_SYMBOL, await client.GetSymbol());
+            Assert.AreEqual(TOKEN_DECIMALS, await client.GetDecimals());
+            Assert.AreEqual(BigInteger.Parse(TOKEN_SUPPLY), await client.GetTotalSupply());
             
             Assert.IsNotNull(client.ContractHash);
             Assert.AreEqual(_contractHash.ToString(), client.ContractHash.ToString());
-        }
-
-        [Test, Order(3)]
-        public void SetContractPackageHashTest()
-        {
-            Assert.IsNotNull(_contractPackageHash, "This test must run after InstallContractTest");
-            var client = new ERC20Client(new NetCasperClient(_nodeAddress), CHAIN_NAME);
-
-            var b = client.SetContractPackageHash(_contractPackageHash, null, true);
-            Assert.IsTrue(b);
-
-            var ex = Assert.Catch(() => client.SetContractPackageHash(_contractPackageHash, null, false));
-            Assert.IsNotNull(ex);
         }
 
         [Test, Order(3)]
@@ -157,8 +142,7 @@ namespace Casper.Network.SDK.Clients.Test
             Assert.IsNotNull(_contractPackageHash, "This test must run after InstallContractTest");
             var client = new ERC20Client(new NetCasperClient(_nodeAddress), CHAIN_NAME);
             
-            var b = client.SetContractPackageHash(_contractPackageHash, null, true);
-            Assert.IsTrue(b);
+            client.SetContractPackageHash(_contractPackageHash, null);
             
             var deployHelper = client.TransferTokens(_ownerAccount.PublicKey,
                 _user2AccountKey,
@@ -345,8 +329,7 @@ namespace Casper.Network.SDK.Clients.Test
             Assert.IsNotNull(_contractPackageHash, "This test must run after InstallContractTest");
             var client = new ERC20Client(new NetCasperClient(_nodeAddress), CHAIN_NAME);
             
-            var b = client.SetContractPackageHash(_contractPackageHash, null, true);
-            Assert.IsTrue(b);
+            client.SetContractPackageHash(_contractPackageHash, null);
 
             var ex = Assert.CatchAsync(() => client.GetBalance(_ownerAccountKey));
             Assert.IsNotNull(ex);

--- a/Casper.Network.SDK.Clients/CEP47Client.cs
+++ b/Casper.Network.SDK.Clients/CEP47Client.cs
@@ -13,19 +13,22 @@ namespace Casper.Network.SDK.Clients
     public partial class CEP47Client : ClientBase, ICEP47Client
     {
         /// <summary>
-        /// Name of the CEP47 token
+        /// Gets the name of the CEP47 token
         /// </summary>
-        public string Name { get; private set; }
+        public async Task<string> GetName() =>
+            (await GetNamedKey<CLValue>("name")).ToString();
 
         /// <summary>
-        /// Symbol of the CEP47 token
+        /// Gets the symbol of the CEP47 token
         /// </summary>
-        public string Symbol { get; private set; }
+        public async Task<string> GetSymbol() =>
+            (await GetNamedKey<CLValue>("symbol")).ToString();
 
         /// <summary>
-        /// Metadata of the CEP47 token
+        /// Gets the metadata of the CEP47 token
         /// </summary>
-        public Dictionary<string, string> Meta { get; private set; }
+        public async Task<Dictionary<string, string>> GetMetadata() =>
+            (await GetNamedKey<CLValue>("meta")).ToDictionary<string, string>();
 
         /// <summary>
         /// Constructor of the client. Call SetContractHash or SetContractPackageHash before any other method. 
@@ -40,7 +43,7 @@ namespace Casper.Network.SDK.Clients
                 var executionResult = result.ExecutionResults.FirstOrDefault();
                 if (executionResult is null)
                     throw new ContractException("ExecutionResults null for processed deploy.",
-                        (long) ERC20ClientErrors.OtherError);
+                        (long) CEP47ClientErrors.OtherError);
 
                 if (executionResult.IsSuccess)
                     return;
@@ -64,31 +67,6 @@ namespace Casper.Network.SDK.Clients
                 throw new ContractException("Deploy not executed. " + executionResult.ErrorMessage,
                     (long) CEP47ClientErrors.OtherError);
             };
-        }
-
-        /// <summary>
-        /// Sets the contract hash to use for all calls to the contract
-        /// </summary>
-        /// <param name="contractHash">A valid Contract hash.</param>
-        /// <param name="skipNamedkeysQuery">Set this to true to skip the retrieval of the default named keys during initialization.</param>
-        /// <returns>False in case of an error retrieving the contract named keys. True otherwise.</returns>
-        public override async Task<bool> SetContractHash(GlobalStateKey contractHash, bool skipNamedkeysQuery = false)
-        {
-            ContractHash = contractHash as HashKey;
-
-            if (!skipNamedkeysQuery)
-            {
-                var result = await GetNamedKey<CLValue>("name");
-                Name = result.ToString();
-
-                result = await GetNamedKey<CLValue>("symbol");
-                Symbol = result.ToString();
-
-                result = await GetNamedKey<CLValue>("meta");
-                Meta = result.ToDictionary<string, string>();
-            }
-
-            return true;
         }
 
         /// <summary>

--- a/Casper.Network.SDK.Clients/ERC20Client.cs
+++ b/Casper.Network.SDK.Clients/ERC20Client.cs
@@ -13,24 +13,28 @@ namespace Casper.Network.SDK.Clients
     public class ERC20Client : ClientBase, IERC20Client
     {
         /// <summary>
-        /// Name of the ERC20 token
+        /// Gets the name of the ERC20 token
         /// </summary>
-        public string Name { get; private set; }
+        public async Task<string> GetName() =>
+            (await GetNamedKey<CLValue>("name")).ToString();
 
         /// <summary>
         /// Symbol of the ERC20 token
         /// </summary>
-        public string Symbol { get; private set; }
+        public async Task<string> GetSymbol() =>
+            (await GetNamedKey<CLValue>("symbol")).ToString();
 
         /// <summary>
         /// Decimals of the ERC20 token.
         /// </summary>
-        public byte Decimals { get; private set; }
+        public async Task<byte> GetDecimals() =>
+            (await GetNamedKey<CLValue>("decimals")).ToByte();
 
         /// <summary>
         /// Total supply of the ERC20 token.
         /// </summary>
-        public BigInteger TotalSupply { get; private set; }
+        public async Task<BigInteger> GetTotalSupply() =>
+            (await GetNamedKey<CLValue>("total_supply")).ToBigInteger();
 
         /// <summary>
         /// Constructor of the client. Call SetContractHash or SetContractPackageHash before any other method. 
@@ -62,34 +66,6 @@ namespace Casper.Network.SDK.Clients
                 throw new ContractException("Deploy not executed. " + executionResult.ErrorMessage,
                     (long) ERC20ClientErrors.OtherError);
             };
-        }
-
-        /// <summary>
-        /// Stores the contract hash and, optionally, retrieves the ERC20 contract main details.
-        /// </summary>
-        /// <param name="contractHash">Contract hash of the contract</param>
-        /// <param name="skipNamedkeysQuery">Set this to true to skip the retrieval of the default named keys during initialization.</param>
-        /// <returns>False in case of an error retrieving the contract named keys. True otherwise.</returns>
-        public override async Task<bool> SetContractHash(GlobalStateKey contractHash, bool skipNamedkeysQuery = false)
-        {
-            ContractHash = contractHash as HashKey;
-
-            if (!skipNamedkeysQuery)
-            {
-                var result = await GetNamedKey<CLValue>("name");
-                Name = result.ToString();
-
-                result = await GetNamedKey<CLValue>("symbol");
-                Symbol = result.ToString();
-
-                result = await GetNamedKey<CLValue>("decimals");
-                Decimals = result.ToByte();
-
-                result = await GetNamedKey<CLValue>("total_supply");
-                TotalSupply = result.ToBigInteger();
-            }
-
-            return true;
         }
 
         /// <summary>

--- a/Casper.Network.SDK.Clients/ICEP47Client.cs
+++ b/Casper.Network.SDK.Clients/ICEP47Client.cs
@@ -8,44 +8,38 @@ namespace Casper.Network.SDK.Clients
     public interface ICEP47Client
     {
         /// <summary>
-        /// Name of the CEP47 token
+        /// Gets the name of the CEP47 token
         /// </summary>
-        string Name { get; }
+        Task<string> GetName();
 
         /// <summary>
-        /// Symbol of the CEP47 token
+        /// Gets the symbol of the CEP47 token
         /// </summary>
-        string Symbol { get; }
+        Task<string> GetSymbol();
 
         /// <summary>
-        /// Metadata of the CEP47 token
+        /// Gets the metadata of the CEP47 token
         /// </summary>
-        Dictionary<string, string> Meta { get; }
+        Task<Dictionary<string, string>> GetMetadata();
 
         /// <summary>
         /// Looks up the contract hash to use for all calls to the contract in a named key of an account.
         /// </summary>
         /// <param name="publicKey">Account that contains a named key with the contract hash.</param>
         /// <param name="namedKey">Named key that contains the contract hash.</param>
-        /// <param name="skipNamedkeysQuery">Set this to true to skip the retrieval of the default named keys during initialization.</param>
-        /// <returns>True if the contract hash and, optionally, the named keys have been retrieved.</returns>
-        Task<bool> SetContractHash(PublicKey publicKey, string namedKey, bool skipNamedkeysQuery=false);
+        Task SetContractHash(PublicKey publicKey, string namedKey);
 
         /// <summary>
         /// Sets the contract hash to use for all calls to the contract
         /// </summary>
         /// <param name="contractHash">Contract hash of the contract</param>
-        /// <param name="skipNamedkeysQuery">Set this to true to skip the retrieval of the default named keys during initialization.</param>
-        /// <returns>False in case of an error retrieving the contract named keys. True otherwise.</returns>
-        Task<bool> SetContractHash(string contractHash, bool skipNamedkeysQuery=false);
+        void SetContractHash(string contractHash);
 
         /// <summary>
         /// Sets the contract hash to use for all calls to the contract
         /// </summary>
         /// <param name="contractHash">A valid Contract hash.</param>
-        /// <param name="skipNamedkeysQuery">Set this to true to skip the retrieval of the default named keys during initialization.</param>
-        /// <returns>False in case of an error retrieving the contract named keys. True otherwise.</returns>
-        Task<bool> SetContractHash(GlobalStateKey contractHash, bool skipNamedkeysQuery=false);
+        void SetContractHash(GlobalStateKey contractHash);
 
         /// <summary>
         /// Initialization of the client with a contract package hash allows to make contract method calls, but it does not allow
@@ -53,9 +47,7 @@ namespace Casper.Network.SDK.Clients
         /// </summary>
         /// <param name="contractPackageHash">The contract package hash to use for all calls to the contract.</param>
         /// <param name="contractVersion">The version number of the contract to call. Use null to call latest version.</param>
-        /// <param name="skipNamedkeysQuery">Must be true. Call SetContractHash if you need to read named keys.</param>
-        /// <returns>False in case of an error. True otherwise.</returns>
-        bool SetContractPackageHash(GlobalStateKey contractPackageHash, uint? contractVersion, bool skipNamedkeysQuery=false);
+        void SetContractPackageHash(GlobalStateKey contractPackageHash, uint? contractVersion);
 
         /// <summary>
         /// Prepares a Deploy to make a new install of the CEP47 contract with the given details.

--- a/Casper.Network.SDK.Clients/IERC20Client.cs
+++ b/Casper.Network.SDK.Clients/IERC20Client.cs
@@ -7,49 +7,43 @@ namespace Casper.Network.SDK.Clients
     public interface IERC20Client
     {
         /// <summary>
-        /// Name of the ERC20 token
+        /// Gets the name of the ERC20 token
         /// </summary>
-        string Name { get; }
+        Task<string> GetName();
 
         /// <summary>
-        /// Symbol of the ERC20 token
+        /// Gets the symbol of the ERC20 token
         /// </summary>
-        string Symbol { get; }
+        Task<string> GetSymbol();
 
         /// <summary>
-        /// Decimals of the ERC20 token.
+        /// Gets the decimals number of the ERC20 token.
         /// </summary>
-        byte Decimals { get; }
+        Task<byte> GetDecimals();
 
         /// <summary>
-        /// Total supply of the ERC20 token.
+        /// Gets the total supply of the ERC20 token.
         /// </summary>
-        BigInteger TotalSupply { get; }
+        Task<BigInteger> GetTotalSupply();
 
         /// <summary>
         /// Looks up the contract hash to use for all calls to the contract in a named key of an account.
         /// </summary>
         /// <param name="publicKey">Account that contains a named key with the contract hash.</param>
         /// <param name="namedKey">Named key that contains the contract hash.</param>
-        /// <param name="skipNamedkeysQuery">Set this to true to skip the retrieval of the default named keys during initialization.</param>
-        /// <returns>True if the contract hash and, optionally, the named keys have been retrieved.</returns>
-        Task<bool> SetContractHash(PublicKey publicKey, string namedKey, bool SkipNamedkeysQuery=false);
+        Task SetContractHash(PublicKey publicKey, string namedKey);
 
         /// <summary>
         /// Sets the contract hash to use for all calls to the contract
         /// </summary>
         /// <param name="contractHash">Contract hash of the contract</param>
-        /// <param name="skipNamedkeysQuery">Set this to true to skip the retrieval of the default named keys during initialization.</param>
-        /// <returns>False in case of an error retrieving the contract named keys. True otherwise.</returns>
-        Task<bool> SetContractHash(string contractHash, bool SkipNamedkeysQuery=false);
+        void SetContractHash(string contractHash);
 
         /// <summary>
         /// Sets the contract hash to use for all calls to the contract
         /// </summary>
         /// <param name="contractHash">A valid Contract hash.</param>
-        /// <param name="skipNamedkeysQuery">Set this to true to skip the retrieval of the default named keys during initialization.</param>
-        /// <returns>False in case of an error retrieving the contract named keys. True otherwise.</returns>
-        Task<bool> SetContractHash(GlobalStateKey contractHash, bool SkipNamedkeysQuery=false);
+        void SetContractHash(GlobalStateKey contractHash);
 
         /// <summary>
         /// Initialization of the client with a contract package hash allows to make contract method calls, but it does not allow
@@ -57,9 +51,7 @@ namespace Casper.Network.SDK.Clients
         /// </summary>
         /// <param name="contractPackageHash">The contract package hash to use for all calls to the contract.</param>
         /// <param name="contractVersion">The version number of the contract to call. Use null to call latest version.</param>
-        /// <param name="skipNamedkeysQuery">Must be true. Call SetContractHash if you need to read named keys.</param>
-        /// <returns>False in case of an error. True otherwise.</returns>
-        bool SetContractPackageHash(GlobalStateKey contractPackageHash, uint? contractVersion, bool skipNamedkeysQuery=false);
+        void SetContractPackageHash(GlobalStateKey contractPackageHash, uint? contractVersion);
 
         /// <summary>
         /// Prepares a Deploy to make a new install of the ERC20 contract with the given details.


### PR DESCRIPTION
### Summary

Changed interface to retrieve contract named keys with Get* methods instead of properties.

### TODO

- [ ] ...

### Checklist

- [x] Code is properly formatted
- [ ] All commits are signed
- [x] Tests included/updated or not needed
- [x] Documentation (manuals or wiki) has been updated or is not required

